### PR TITLE
⚡ Fix broken parallel processing and enable h5py in ssppop_fitting

### DIFF
--- a/ngistPipeline/lineStrengths/ssppop_fitting.py
+++ b/ngistPipeline/lineStrengths/ssppop_fitting.py
@@ -5,9 +5,9 @@ import sys
 import warnings
 
 import emcee
-# from   joblib              import Parallel, delayed
+from   joblib              import Parallel, delayed
 import matplotlib.pyplot as plt
-# import h5py
+import h5py
 import numpy
 import scipy.spatial.qhull as qhull
 from astropy.io import fits
@@ -415,6 +415,9 @@ if __name__ == "__main__":
             nchain,
             plot,
             verbose,
+            i,
+            ncases,
+            "",
         )
         for i in range(ncases)
     )


### PR DESCRIPTION
I have fixed the broken parallel processing imports and call in `ngistPipeline/lineStrengths/ssppop_fitting.py`. 

Specifically:
- Uncommented `from joblib import Parallel, delayed` and `import h5py`.
- Updated the `Parallel` call to correctly pass `progress`, `ncases`, and `outdir` arguments to the `ssppop_fitting` function.

These changes enable parallelized MCMC fitting when the script is run standalone, providing a significant performance boost on multi-core systems. It also fixes a bug where the script would fail due to missing arguments in the parallel call.

---
*PR created automatically by Jules for task [15940090230614769580](https://jules.google.com/task/15940090230614769580) started by @drtobybrown*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a standalone fitting script: re-enables imports and fixes argument passing for parallel execution; main risk is runtime dependency availability (`joblib`, `h5py`) and differing behavior when running in parallel.
> 
> **Overview**
> Fixes `ssppop_fitting.py` so it can run MCMC fitting in parallel again by re-enabling the `joblib` (`Parallel`, `delayed`) import and passing the previously-missing `progress`, `ncases`, and `outdir` arguments into the `delayed(ssppop_fitting)` call.
> 
> Also re-enables `h5py` import so the script can write MCMC chains to an HDF5 output file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cd064454cffed27446826cc2d590a8868a540c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->